### PR TITLE
adding missing port key to address object

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,7 +24,7 @@ const HazelcastClient = require('hazelcast-client').Client;
 const HazelcastConfig = require('hazelcast-client').Config;
 
 const clientConfig = new HazelcastConfig.ClientConfig();
-clientConfig.networkConfig.addresses = [{host: '127.0.0.1', 5701}];
+clientConfig.networkConfig.addresses = [{host: '127.0.0.1', port: 5701}];
 
 HazelcastClient.newHazelcastClient(clientConfig).then((hzInstance) => {  
   hazelcastStore.setClient(hzInstance);


### PR DESCRIPTION
A trivial update, but as I was going through the docs, I saw this port key was missing in the address object. Had to look it up and just wanted to try and help someone else who was doing the same thing.